### PR TITLE
Show example link Markdown source in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ It is more consistent once you get to more than three levels.
 ### Links
 
 When writing links, use **relative path** and `.md` extension. So for example
-[README](README.md). When documentation is build, they get converted to working
-links (without `.md`).
+`[README](README.md)` will create a link like so: [README](README.md). When
+documentation is built, they get converted to working links (without `.md`).
 
 ### Images
 


### PR DESCRIPTION
Minor formatting change so the example link shows as raw characters, alongside its rendered example.

Also includes one grammar fix as well (built vs build).