### PR TITLE
Include "enable" in upstart for haas-proxy (first installation)

### DIFF
--- a/docs/basics/collect/setup.md
+++ b/docs/basics/collect/setup.md
@@ -32,5 +32,6 @@ naming it, you will get a **token**
 ```
 uci set haas.settings.token="YOUR_TOKEN"
 uci commit
+/etc/init.d/haas-proxy enable
 /etc/init.d/haas-proxy start
 ```


### PR DESCRIPTION
Added enable to haas-proxy service. Otherwise it will not start on reboot.